### PR TITLE
Make an arbitrary directory root

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 JP_S3_BUCKET=<S3 Bucket Name>
+JP_S3_ROOT=<Path to directory within S3 Bucket to act as root>
 JP_S3_REGION=<S3 Bucket Region>
 JP_S3_ENDPOINT=<S3 Custom Endpoint>
 JP_S3_ACCESS_KEY_ID=<S3 Access Key ID / IAM Access Key ID>

--- a/src/index.ts
+++ b/src/index.ts
@@ -243,20 +243,25 @@ namespace Private {
    */
   const createSwitchDriveNode = (oldDriveName: string): HTMLElement => {
     const body = document.createElement('div');
+
     const existingLabel = document.createElement('label');
-    existingLabel.textContent = 'Current Drive';
-    const existingName = document.createElement('span');
-    existingName.textContent = oldDriveName;
+    existingLabel.textContent = 'Current Drive: ' + oldDriveName;
 
     const nameTitle = document.createElement('label');
     nameTitle.textContent = 'Switch to another Drive';
     nameTitle.className = SWITCH_DRIVE_TITLE_CLASS;
     const name = document.createElement('input');
 
+    const root = document.createElement('label');
+    root.textContent = 'with root';
+    root.className = SWITCH_DRIVE_TITLE_CLASS;
+    const rootPath = document.createElement('input');
+
     body.appendChild(existingLabel);
-    body.appendChild(existingName);
     body.appendChild(nameTitle);
     body.appendChild(name);
+    body.appendChild(root);
+    body.appendChild(rootPath);
     return body;
   };
 
@@ -339,22 +344,31 @@ namespace Private {
 
     protected onAfterAttach(): void {
       this.addClass(FILE_DIALOG_CLASS);
-      const value = this.inputNode.value;
-      this.inputNode.setSelectionRange(0, value.length);
+      const name = this.inputNameNode.value;
+      this.inputNameNode.setSelectionRange(0, name.length);
+      const root = this.inputRootNode.value;
+      this.inputRootNode.setSelectionRange(0, root.length);
     }
 
     /**
-     * Get the input text node.
+     * Get the input text node for bucket name.
      */
-    get inputNode(): HTMLInputElement {
+    get inputNameNode(): HTMLInputElement {
       return this.node.getElementsByTagName('input')[0] as HTMLInputElement;
+    }
+
+    /**
+     * Get the input text node for path to root.
+     */
+    get inputRootNode(): HTMLInputElement {
+      return this.node.getElementsByTagName('input')[1] as HTMLInputElement;
     }
 
     /**
      * Get the value of the widget.
      */
-    getValue(): string {
-      return this.inputNode.value;
+    getValue(): string[] {
+      return [this.inputNameNode.value, this.inputRootNode.value];
     }
   }
 
@@ -377,7 +391,8 @@ namespace Private {
           ]
         }).then(result => {
           if (result.value) {
-            drive.name = result.value;
+            drive.name = result.value[0];
+            drive.root = result.value[1];
             app.serviceManager.contents.addDrive(drive);
           }
         });

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,7 @@ const SWITCH_DRIVE_TITLE_CLASS = 'jp-new-drive-title';
 export interface IS3Auth {
   factory: () => Promise<{
     bucket: string;
+    root: string;
     config: S3ClientConfig;
   }>;
 }
@@ -84,6 +85,7 @@ const authFileBrowser: JupyterFrontEndPlugin<IS3Auth> = {
     return {
       factory: async () => ({
         bucket: process.env.JP_S3_BUCKET ?? 'jupyter-drives-test-bucket-1',
+        root: process.env.JP_S3_ROOT ?? '',
         config: {
           forcePathStyle: true,
           endpoint: process.env.JP_S3_ENDPOINT ?? 'https://example.com/s3',
@@ -121,7 +123,11 @@ const defaultFileBrowser: JupyterFrontEndPlugin<IDefaultFileBrowser> = {
     const { commands } = app;
     const auth = await s3auth.factory();
     // create S3 drive
-    const S3Drive = new Drive({ name: auth.bucket, config: auth.config });
+    const S3Drive = new Drive({
+      name: auth.bucket,
+      root: auth.root,
+      config: auth.config
+    });
 
     app.serviceManager.contents.addDrive(S3Drive);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -296,33 +296,31 @@ namespace Private {
       this.onAfterAttach();
     }
 
-    protected onAfterAttach(): void {
-      this.addClass(FILE_DIALOG_CLASS);
-      const name = this.inputNameNode.value;
-      this.inputNameNode.setSelectionRange(0, name.length);
-      const location = this.inputLocationNode.value;
-      this.inputLocationNode.setSelectionRange(0, location.length);
-    }
-
     /**
-     * Get the input text node for the bucket name.
+     * The text input node for bucket name.
      */
-    get inputNameNode(): HTMLInputElement {
+    protected get bucketInput(): HTMLInputElement {
       return this.node.getElementsByTagName('input')[0] as HTMLInputElement;
     }
-
     /**
-     * Get the input text node for the location within the bucket.
+     * The text input node root directory.
      */
-    get inputLocationNode(): HTMLInputElement {
+    protected get rootInput(): HTMLInputElement {
       return this.node.getElementsByTagName('input')[1] as HTMLInputElement;
+    }
+
+    protected onAfterAttach(): void {
+      this.addClass(FILE_DIALOG_CLASS);
+      const [bucket, root] = this.getValue();
+      this.bucketInput.setSelectionRange(0, bucket.length);
+      this.rootInput.setSelectionRange(0, root.length);
     }
 
     /**
      * Get the value of the widget.
      */
-    getValue(): string[] {
-      return [this.inputNameNode.value, this.inputLocationNode.value];
+    getValue(): [bucket: string, root: string] {
+      return [this.bucketInput.value, this.rootInput.value];
     }
   }
 

--- a/src/s3contents.ts
+++ b/src/s3contents.ts
@@ -775,9 +775,7 @@ export class Drive implements Contents.IDrive {
             newLocalPath,
             this._name
           );
-          return this.delete_file(
-            oldLocalPath.replace(this._root + '/', '') + remainingFilePath
-          );
+          return this.delete_file(oldLocalPath + remainingFilePath);
         });
         await Promise.all(promises);
       }
@@ -1281,7 +1279,7 @@ export class Drive implements Contents.IDrive {
 
   /**
    * Helping function for deleting files inside
-   * a directory, in the case of deleting the directory.
+   * a directory, in the case of deleting or renaming a directory.
    *
    * @param filePath complete path of file to delete
    */

--- a/src/s3contents.ts
+++ b/src/s3contents.ts
@@ -50,7 +50,7 @@ export class Drive implements Contents.IDrive {
    * @param options - The options used to initialize the object.
    */
   constructor(options: Drive.IOptions) {
-    const { config, name } = options;
+    const { config, name, root } = options;
     this._serverSettings = ServerConnection.makeSettings();
     this._s3Client = new S3Client(config ?? {});
     this._name = name;
@@ -68,7 +68,9 @@ export class Drive implements Contents.IDrive {
         this._region = region!;
       });
     }
-
+    this.formatRoot(root).then((root: string) => {
+      this._root = root;
+    });
     this._registeredFileTypes = {};
   }
 
@@ -108,9 +110,24 @@ export class Drive implements Contents.IDrive {
   }
 
   /**
-   * The Drive name setter */
+   * The Drive name setter
+   */
   set name(name: string) {
     this._name = name;
+  }
+
+  /**
+   * The Drive root getter
+   */
+  get root(): string {
+    return this._root;
+  }
+
+  /**
+   * The Drive root setter
+   */
+  set root(root: string) {
+    this._root = root;
   }
 
   /**
@@ -269,7 +286,8 @@ export class Drive implements Contents.IDrive {
       const fileList: IContentsList = {};
 
       const command = new ListObjectsV2Command({
-        Bucket: this._name
+        Bucket: this._name,
+        Prefix: this._root
       });
 
       let isTruncated: boolean | undefined = true;
@@ -280,23 +298,29 @@ export class Drive implements Contents.IDrive {
 
         if (Contents) {
           Contents.forEach(c => {
-            const fileName = c.Key!.split('/')[0];
-            const [fileType, fileMimeType, fileFormat] = this.getFileType(
-              fileName.split('.')[1]
-            );
+            if (c.Key! !== this._root + '/') {
+              const fileName = (
+                this._root === ''
+                  ? c.Key!
+                  : c.Key!.replace(this._root + '/', '')
+              ).split('/')[0];
+              const [fileType, fileMimeType, fileFormat] = this.getFileType(
+                fileName.split('.')[1]
+              );
 
-            fileList[fileName] = fileList[fileName] ?? {
-              name: fileName,
-              path: fileName,
-              last_modified: c.LastModified!.toISOString(),
-              created: '',
-              content: !fileName.split('.')[1] ? [] : null,
-              format: fileFormat as Contents.FileFormat,
-              mimetype: fileMimeType,
-              size: c.Size!,
-              writable: true,
-              type: fileType
-            };
+              fileList[fileName] = fileList[fileName] ?? {
+                name: fileName,
+                path: fileName,
+                last_modified: c.LastModified!.toISOString(),
+                created: '',
+                content: !fileName.split('.')[1] ? [] : null,
+                format: fileFormat as Contents.FileFormat,
+                mimetype: fileMimeType,
+                size: c.Size!,
+                writable: true,
+                type: fileType
+              };
+            }
           });
         }
         if (isTruncated) {
@@ -383,7 +407,7 @@ export class Drive implements Contents.IDrive {
       else {
         const command = new GetObjectCommand({
           Bucket: this._name,
-          Key: path.replace(this._name + '/', '')
+          Key: this._root ? this._root + '/' + path : path
         });
 
         const response = await this._s3Client.send(command);
@@ -411,7 +435,7 @@ export class Drive implements Contents.IDrive {
 
           data = {
             name: currentPath,
-            path: path,
+            path: this._root ? this._root + '/' + path : path,
             last_modified: date,
             created: '',
             content: fileContents,
@@ -441,6 +465,8 @@ export class Drive implements Contents.IDrive {
     options: Contents.ICreateOptions = {}
   ): Promise<Contents.IModel> {
     const body = '';
+    let { path, type, ext } = options;
+    path = this._root ? (path ? this._root + '/' + path : this._root) : path;
 
     // get current list of contents of drive
     const content: Contents.IModel[] = [];
@@ -494,24 +520,22 @@ export class Drive implements Contents.IDrive {
       type: 'directory'
     };
 
-    if (options.type !== undefined) {
-      if (options.type !== 'directory') {
-        const name = this.incrementUntitledName(old_data, options);
+    if (type !== undefined) {
+      if (type !== 'directory') {
+        const name = this.incrementUntitledName(old_data, { path, type, ext });
         await this.s3Client.send(
           new PutObjectCommand({
             Bucket: this._name,
-            Key: options.path ? options.path + '/' + name : name,
+            Key: path ? path + '/' + name : name,
             Body: body
           })
         );
 
-        const [fileType, fileMimeType, fileFormat] = this.getFileType(
-          options.ext!
-        );
+        const [fileType, fileMimeType, fileFormat] = this.getFileType(ext!);
 
         data = {
           name: name,
-          path: options.path + '/' + name,
+          path: path + '/' + name,
           last_modified: new Date().toISOString(),
           created: new Date().toISOString(),
           content: body,
@@ -523,18 +547,18 @@ export class Drive implements Contents.IDrive {
         };
       } else {
         // creating a new directory
-        const name = this.incrementUntitledName(old_data, options);
+        const name = this.incrementUntitledName(old_data, { path, type, ext });
         await this.s3Client.send(
           new PutObjectCommand({
             Bucket: this._name,
-            Key: options.path ? options.path + '/' + name + '/' : name + '/',
+            Key: path ? path + '/' + name + '/' : name + '/',
             Body: body
           })
         );
 
         data = {
           name: name,
-          path: options.path + '/' + name,
+          path: path + '/' + name,
           last_modified: new Date().toISOString(),
           created: new Date().toISOString(),
           content: [],
@@ -542,7 +566,7 @@ export class Drive implements Contents.IDrive {
           mimetype: 'text/directory',
           size: undefined,
           writable: true,
-          type: options.type
+          type: type
         };
       }
     } else {
@@ -621,6 +645,11 @@ export class Drive implements Contents.IDrive {
    * @returns A promise which resolves when the file is deleted.
    */
   async delete(localPath: string): Promise<void> {
+    localPath = this._root
+      ? localPath
+        ? this._root + '/' + localPath
+        : this._root
+      : localPath;
     // get list of contents with given prefix (path)
     const command = new ListObjectsV2Command({
       Bucket: this._name,
@@ -677,6 +706,8 @@ export class Drive implements Contents.IDrive {
       newLocalPath.indexOf('/') >= 0
         ? newLocalPath.split('/')[newLocalPath.split('/').length - 1]
         : newLocalPath;
+    newLocalPath = this._root ? this._root + '/' + newLocalPath : newLocalPath;
+    oldLocalPath = this._root ? this._root + '/' + oldLocalPath : oldLocalPath;
 
     const [fileType, fileMimeType, fileFormat] = this.getFileType(
       newFileName!.split('.')[1]
@@ -763,7 +794,7 @@ export class Drive implements Contents.IDrive {
     }
 
     // delete old file or directory with its contents
-    this.delete(oldLocalPath);
+    this.delete(oldLocalPath.replace(this._root + '/', ''));
 
     // manually refresh filebrowser contents
     this._fileBrowserModel!.refresh();
@@ -873,6 +904,7 @@ export class Drive implements Contents.IDrive {
       localPath.indexOf('/') === -1
         ? localPath
         : localPath.split('/')[localPath.split.length - 1];
+    localPath = this._root ? this._root + '/' + localPath : localPath;
 
     const [fileType, fileMimeType, fileFormat] = this.getFileType(
       fileName.split('.')[1]
@@ -999,6 +1031,9 @@ export class Drive implements Contents.IDrive {
     toDir: string,
     options: Contents.ICreateOptions = {}
   ): Promise<Contents.IModel> {
+    path = this._root ? this._root + '/' + path : path;
+    toDir = this._root ? this._root + (toDir ? '/' + toDir : toDir) : toDir;
+
     const isDir: boolean = path.split('.').length === 1;
 
     // construct new file or directory name for the copy
@@ -1088,6 +1123,7 @@ export class Drive implements Contents.IDrive {
   ): Promise<Contents.IModel> {
     path =
       path[path.length - 1] === '/' ? path.substring(0, path.length - 1) : path;
+    path = this._root ? this._root + (path ? '/' + path : path) : path;
 
     // list contents of path - contents of directory or one file
     const command = new ListObjectsV2Command({
@@ -1324,9 +1360,42 @@ export class Drive implements Contents.IDrive {
     return [fileType, fileMimetype, fileFormat];
   }
 
+  /**
+   * Helping function which formats root by removing all leading or trailing
+   * backslashes and checking if given path to directory exists.
+   *
+   * @param root
+   * @returns formatted root
+   */
+  private async formatRoot(root: string) {
+    // if root is empty, no formatting needed
+    if (root === '') {
+      return root;
+    }
+
+    // reformat the path to arbitrary root so it has no leading or trailing /
+    root = root.replace(/^\/+|\/+$/g, '');
+
+    // check if directory exists within bucket
+    try {
+      await this._s3Client.send(
+        new HeadObjectCommand({
+          Bucket: this._name,
+          Key: root + '/'
+        })
+      );
+      // the directory exists, root is formatted correctly
+      return root;
+    } catch (error) {
+      console.log("Given path to root directory doesn't exist within bucket.");
+      return '';
+    }
+  }
+
   private _serverSettings: ServerConnection.ISettings;
   private _s3Client: S3Client;
   private _name: string = '';
+  private _root: string = '';
   private _provider: string = '';
   private _baseUrl: string = '';
   private _region: string = '';
@@ -1353,6 +1422,11 @@ export namespace Drive {
      * paths to disambiguate it from other drives.
      */
     name: string;
+
+    /**
+     * Path to directory from drive, which acts as root.
+     */
+    root: string;
 
     /**
      * The server settings for the server.

--- a/src/s3contents.ts
+++ b/src/s3contents.ts
@@ -127,7 +127,7 @@ export class Drive implements Contents.IDrive {
    * The Drive root setter
    */
   set root(root: string) {
-    this._root = root;
+    this.formatRoot(root).then(root => (this._root = root));
   }
 
   /**


### PR DESCRIPTION
Added a `root` parameter to the authentication plugin - a variable containing the path to a directory within the bucket, which will act as a new root of the drive inside the FileBrowser. If left empty, the root will be considered as the default one (the directory holding the contents of the entire bucket).

When being set for the `Drive` object, the `root` is automatically formatted accordingly with the use of a helper function, which makes sure all leading and trailing `/` are eliminated and the path leads to an existing directory within the chosen bucket. If the path is faulty, the`root` becomes the default one.

Updated the logic of all existing functionalities to consider the root when extracting the path, if it exists, and added a new `root` parameter in the dialog box for switching to another drive (if the parameter is left empty, the default one is considered).