### PR TITLE
Improve switching drives functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
         "@aws-sdk/client-s3": "^3.511.0",
         "@aws-sdk/s3-request-presigner": "^3.511.0",
         "@jupyterlab/application": "^4.0.0",
+        "@jupyterlab/statedb": "^4.2.2",
         "@lumino/coreutils": "2.1.2"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
         "@aws-sdk/client-s3": "^3.511.0",
         "@aws-sdk/s3-request-presigner": "^3.511.0",
         "@jupyterlab/application": "^4.0.0",
-        "@jupyterlab/statedb": "^4.2.2",
         "@jupyterlab/coreutils": "^6.2.2",
+        "@jupyterlab/statedb": "^4.2.2",
         "@lumino/coreutils": "2.1.2"
     },
     "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,9 +137,6 @@ const defaultFileBrowser: JupyterFrontEndPlugin<IDefaultFileBrowser> = {
 
     app.serviceManager.contents.addDrive(S3Drive);
 
-    // save drive name to the persistent state database
-    // state.save(S3Drive.name, { bucket: S3Drive.name });
-
     // get registered file types
     S3Drive.getRegisteredFileTypes(app);
 
@@ -157,12 +154,9 @@ const defaultFileBrowser: JupyterFrontEndPlugin<IDefaultFileBrowser> = {
       .then(() => state.fetch(id))
       .then(value => {
         if (value) {
-          console.log('Read from state value: ', value);
           const bucket = (value as ReadonlyPartialJSONObject)[
             'bucket'
           ] as string;
-
-          console.log('bucket: ', bucket);
 
           // if value is stored, change bucket name
           S3Drive.name = bucket;
@@ -416,10 +410,6 @@ namespace Private {
             drive.root = result.value[1];
             app.serviceManager.contents.addDrive(drive);
 
-            console.log(
-              'save new drive name to persistent database: ',
-              drive.name
-            );
             // saving the new drive name to the persistent state database
             state.save(id, { bucket: drive.name });
           }

--- a/src/index.ts
+++ b/src/index.ts
@@ -157,9 +157,11 @@ const defaultFileBrowser: JupyterFrontEndPlugin<IDefaultFileBrowser> = {
           const bucket = (value as ReadonlyPartialJSONObject)[
             'bucket'
           ] as string;
+          const root = (value as ReadonlyPartialJSONObject)['root'] as string;
 
           // if value is stored, change bucket name
           S3Drive.name = bucket;
+          S3Drive.root = root;
           app.serviceManager.contents.addDrive(S3Drive);
         }
       });
@@ -411,7 +413,7 @@ namespace Private {
             app.serviceManager.contents.addDrive(drive);
 
             // saving the new drive name to the persistent state database
-            state.save(id, { bucket: drive.name });
+            state.save(id, { bucket: result.value[0], root: result.value[1] });
           }
         });
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -263,10 +263,10 @@ namespace Private {
     const existingLabel = document.createElement('label');
     existingLabel.textContent = 'Current Drive: ' + oldDriveName;
 
-    const nameTitle = document.createElement('label');
-    nameTitle.textContent = 'Switch to another Drive';
-    nameTitle.className = SWITCH_DRIVE_TITLE_CLASS;
-    const name = document.createElement('input');
+    const bucket = document.createElement('label');
+    bucket.textContent = 'Switch to another Drive';
+    bucket.className = SWITCH_DRIVE_TITLE_CLASS;
+    const bucketName = document.createElement('input');
 
     const root = document.createElement('label');
     root.textContent = 'with root';
@@ -274,8 +274,8 @@ namespace Private {
     const rootPath = document.createElement('input');
 
     body.appendChild(existingLabel);
-    body.appendChild(nameTitle);
-    body.appendChild(name);
+    body.appendChild(bucket);
+    body.appendChild(bucketName);
     body.appendChild(root);
     body.appendChild(rootPath);
     return body;
@@ -287,20 +287,20 @@ namespace Private {
   const createCopyToAnotherBucketNode = (): HTMLElement => {
     const body = document.createElement('div');
 
-    const nameTitle = document.createElement('label');
-    nameTitle.textContent = 'Copy to another Bucket';
-    nameTitle.className = SWITCH_DRIVE_TITLE_CLASS;
-    const name = document.createElement('input');
+    const bucket = document.createElement('label');
+    bucket.textContent = 'Copy to another Bucket';
+    bucket.className = SWITCH_DRIVE_TITLE_CLASS;
+    const bucketName = document.createElement('input');
 
-    const location = document.createElement('label');
-    location.textContent = 'Location within the Bucket';
-    location.className = SWITCH_DRIVE_TITLE_CLASS;
-    const locationName = document.createElement('input');
+    const root = document.createElement('label');
+    root.textContent = 'Location within the Bucket';
+    root.className = SWITCH_DRIVE_TITLE_CLASS;
+    const rootPath = document.createElement('input');
 
-    body.appendChild(nameTitle);
-    body.appendChild(name);
-    body.appendChild(location);
-    body.appendChild(locationName);
+    body.appendChild(bucket);
+    body.appendChild(bucketName);
+    body.appendChild(root);
+    body.appendChild(rootPath);
     return body;
   };
 
@@ -358,23 +358,23 @@ namespace Private {
 
     protected onAfterAttach(): void {
       this.addClass(FILE_DIALOG_CLASS);
-      const name = this.inputNameNode.value;
-      this.inputNameNode.setSelectionRange(0, name.length);
-      const root = this.inputRootNode.value;
-      this.inputRootNode.setSelectionRange(0, root.length);
+      const bucket = this.bucketInput.value;
+      this.bucketInput.setSelectionRange(0, bucket.length);
+      const root = this.rootInput.value;
+      this.rootInput.setSelectionRange(0, root.length);
     }
 
     /**
      * Get the input text node for bucket name.
      */
-    get inputNameNode(): HTMLInputElement {
+    get bucketInput(): HTMLInputElement {
       return this.node.getElementsByTagName('input')[0] as HTMLInputElement;
     }
 
     /**
      * Get the input text node for path to root.
      */
-    get inputRootNode(): HTMLInputElement {
+    get rootInput(): HTMLInputElement {
       return this.node.getElementsByTagName('input')[1] as HTMLInputElement;
     }
 
@@ -382,7 +382,7 @@ namespace Private {
      * Get the value of the widget.
      */
     getValue(): string[] {
-      return [this.inputNameNode.value, this.inputRootNode.value];
+      return [this.bucketInput.value, this.rootInput.value];
     }
   }
 

--- a/src/s3contents.ts
+++ b/src/s3contents.ts
@@ -309,8 +309,9 @@ export class Drive implements Contents.IDrive {
     const old_data = await listS3Contents(
       this._s3Client,
       this._name,
-      '', // we consider the root undefined in order to retrieve the complete list of contents
-      this.registeredFileTypes
+      this._root,
+      this.registeredFileTypes,
+      options.path
     );
 
     if (options.type !== undefined) {

--- a/src/s3contents.ts
+++ b/src/s3contents.ts
@@ -113,6 +113,14 @@ export class Drive implements Contents.IDrive {
    */
   set name(name: string) {
     this._name = name;
+
+     // if name of drive is changed, the filebrowser needs to refresh its contents
+    // as we are switching to another bucket
+    this._fileChanged.emit({
+      type: 'new',
+      oldValue: null,
+      newValue: { path: '' }
+    });
   }
 
   /**

--- a/src/s3contents.ts
+++ b/src/s3contents.ts
@@ -114,7 +114,7 @@ export class Drive implements Contents.IDrive {
   set name(name: string) {
     this._name = name;
 
-     // if name of drive is changed, the filebrowser needs to refresh its contents
+    // if name of drive is changed, the filebrowser needs to refresh its contents
     // as we are switching to another bucket
     this._fileChanged.emit({
       type: 'new',

--- a/yarn.lock
+++ b/yarn.lock
@@ -8597,6 +8597,7 @@ __metadata:
     "@aws-sdk/s3-request-presigner": ^3.511.0
     "@jupyterlab/application": ^4.0.0
     "@jupyterlab/builder": ^4.0.0
+    "@jupyterlab/statedb": ^4.2.2
     "@jupyterlab/testutils": ^4.0.0
     "@lumino/coreutils": 2.1.2
     "@types/jest": ^29.2.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -8597,8 +8597,8 @@ __metadata:
     "@aws-sdk/s3-request-presigner": ^3.511.0
     "@jupyterlab/application": ^4.0.0
     "@jupyterlab/builder": ^4.0.0
-    "@jupyterlab/statedb": ^4.2.2
     "@jupyterlab/coreutils": ^6.2.2
+    "@jupyterlab/statedb": ^4.2.2
     "@jupyterlab/testutils": ^4.0.0
     "@lumino/coreutils": 2.1.2
     "@types/jest": ^29.2.0


### PR DESCRIPTION
Emit a `fileChanged` signal when changing the name of the drive, such that when switching to a new drive the filebrowser contents would get updated automatically.

Use the persistent state database `IStateDB` to save and store the current drive name and root. This way, when switching to a new drive, the new bucket name gets saved, and when refreshing the web browser, the filebrowser will get initialized with the correct drive (the latest the user has switched to).