### PR TITLE
Add flag which toggles bucket switching UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
         "@aws-sdk/s3-request-presigner": "^3.511.0",
         "@jupyterlab/application": "^4.0.0",
         "@jupyterlab/coreutils": "^6.2.2",
+        "@jupyterlab/settingregistry": "^4.2.3",
         "@jupyterlab/statedb": "^4.2.2",
         "@lumino/coreutils": "2.1.2"
     },

--- a/schema/file-browser-toolbar.json
+++ b/schema/file-browser-toolbar.json
@@ -2,22 +2,25 @@
   "jupyter.lab.toolbars": {
     "DriveBrowser": [
       {
-        "name": "drive",
-        "command": "drives:open-change-drive-dialog",
+        "name": "switch-drive",
+        "command": "drives:open-switch-drive-dialog",
         "rank": 35
-      },
-      {
-        "name": "new-drive",
-        "command": "drives:open-new-drive-dialog",
-        "rank": 40
       }
     ]
   },
-  "title": "jupydrive-s3:file-browser-toolbar",
+  "jupyter.lab.setting-icon": "jupydrive-s3:drive",
+  "jupyter.lab.setting-icon-label": "Drive Browser",
+  "title": "Jupydrive-s3 Settings",
   "description": "jupydrive-s3 settings.",
   "type": "object",
   "jupyter.lab.transform": true,
   "properties": {
+    "bucketSwitching": {
+      "type": "boolean",
+      "title": "Enable Bucket switching",
+      "description": "This flag enables or disables the bucket switching UI.",
+      "default": false
+    },
     "toolbar": {
       "title": "Drive browser toolbar items",
       "items": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -484,17 +484,6 @@ namespace Private {
         '.jp-SidePanel .jp-DirListing-content .jp-DirListing-item[data-isDir]',
       rank: 10
     });
-
-    // app.commands.addCommand(CommandIDs.toggleBucketSwitching, {
-    //   label: 'Enable Bucket Switching',
-    //   isToggled: () => !!settings.composite['bucketSwitching'],
-    //   execute: () => {
-    //     settings.set('bucketSwitching', !settings.composite['bucketSwitching']);
-    //     console.log(settings.composite['bucketSwitching'])
-    //     console.log('button toggled, reload!')
-    //     location.reload();
-    //   }
-    // });
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,8 +36,9 @@ import { S3ClientConfig } from '@aws-sdk/client-s3';
  */
 namespace CommandIDs {
   export const openPath = 'filebrowser:open-path';
-  export const openChangeDrive = 'drives:open-change-drive-dialog';
+  export const openSwitchDrive = 'drives:open-switch-drive-dialog';
   export const copyToAnotherBucket = 'drives:copy-to-another-bucket';
+  export const toggleBucketSwitching = 'drives:toggle-bucket-switching-ui';
 }
 
 const FILE_BROWSER_FACTORY = 'DriveBrowser';
@@ -61,7 +62,7 @@ const SWITCH_DRIVE_TITLE_CLASS = 'jp-new-drive-title';
 /**
  * The ID used for saving the drive name to the persistent state databse.
  */
-const id = 'jupydrive-s3:drive-name-id';
+const DRIVE_STATE_ID = 'jupydrive-s3:drive-name-id';
 
 /**
  * A promise that resolves to S3 authentication credentials.
@@ -115,13 +116,14 @@ const defaultFileBrowser: JupyterFrontEndPlugin<IDefaultFileBrowser> = {
   id: 'jupydrive-s3:default-file-browser',
   description: 'The default file browser factory provider',
   provides: IDefaultFileBrowser,
-  requires: [IFileBrowserFactory, IS3Auth, IStateDB],
+  requires: [IFileBrowserFactory, IS3Auth, IStateDB, ISettingRegistry],
   optional: [IRouter, JupyterFrontEnd.ITreeResolver, ILabShell],
   activate: async (
     app: JupyterFrontEnd,
     fileBrowserFactory: IFileBrowserFactory,
     s3auth: IS3Auth,
     state: IStateDB,
+    settings: ISettingRegistry,
     router: IRouter | null,
     tree: JupyterFrontEnd.ITreeResolver | null,
     labShell: ILabShell | null
@@ -150,23 +152,41 @@ const defaultFileBrowser: JupyterFrontEndPlugin<IDefaultFileBrowser> = {
       }
     );
 
+    function loadSetting(setting: ISettingRegistry.ISettings): boolean {
+      // Read the settings and convert to the correct type
+      const bucketSwitching = setting.get('bucketSwitching')
+        .composite as boolean;
+      return bucketSwitching;
+    }
+
+    // Wait for the application to be restored and for the
+    // settings and persistent state database to be loaded
     app.restored
-      .then(() => state.fetch(id))
-      .then(value => {
+      .then(() =>
+        Promise.all([
+          state.fetch(DRIVE_STATE_ID),
+          settings.load(toolbarFileBrowser.id)
+        ])
+      )
+      .then(([value, setting]) => {
         if (value) {
           const bucket = (value as ReadonlyPartialJSONObject)[
             'bucket'
           ] as string;
           const root = (value as ReadonlyPartialJSONObject)['root'] as string;
 
-          // if value is stored, change bucket name
+          // if values are stored, change bucket name and root
           S3Drive.name = bucket;
           S3Drive.root = root;
           app.serviceManager.contents.addDrive(S3Drive);
         }
-      });
 
-    Private.addCommands(app, S3Drive, fileBrowserFactory, state);
+        // Listen for the plugin setting changes using Signal.
+        setting.changed.connect(loadSetting);
+
+        // adding commands
+        Private.addCommands(app, S3Drive, fileBrowserFactory, state, setting);
+      });
 
     void Private.restoreBrowser(
       defaultBrowser,
@@ -392,10 +412,15 @@ namespace Private {
     app: JupyterFrontEnd,
     drive: Drive,
     factory: IFileBrowserFactory,
-    state: IStateDB
+    state: IStateDB,
+    settings: ISettingRegistry.ISettings
   ): void {
     const { tracker } = factory;
-    app.commands.addCommand(CommandIDs.openChangeDrive, {
+
+    app.commands.addCommand(CommandIDs.openSwitchDrive, {
+      isVisible: () => {
+        return (settings.get('bucketSwitching').composite as boolean) ?? false;
+      },
       execute: async () => {
         return showDialog({
           body: new Private.SwitchDriveHandler(drive.name),
@@ -413,7 +438,10 @@ namespace Private {
             app.serviceManager.contents.addDrive(drive);
 
             // saving the new drive name to the persistent state database
-            state.save(id, { bucket: result.value[0], root: result.value[1] });
+            state.save(DRIVE_STATE_ID, {
+              bucket: result.value[0],
+              root: result.value[1]
+            });
           }
         });
       },
@@ -456,6 +484,17 @@ namespace Private {
         '.jp-SidePanel .jp-DirListing-content .jp-DirListing-item[data-isDir]',
       rank: 10
     });
+
+    // app.commands.addCommand(CommandIDs.toggleBucketSwitching, {
+    //   label: 'Enable Bucket Switching',
+    //   isToggled: () => !!settings.composite['bucketSwitching'],
+    //   execute: () => {
+    //     settings.set('bucketSwitching', !settings.composite['bucketSwitching']);
+    //     console.log(settings.composite['bucketSwitching'])
+    //     console.log('button toggled, reload!')
+    //     location.reload();
+    //   }
+    // });
   }
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -3196,6 +3196,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/nbformat@npm:^4.2.3":
+  version: 4.2.3
+  resolution: "@jupyterlab/nbformat@npm:4.2.3"
+  dependencies:
+    "@lumino/coreutils": ^2.1.2
+  checksum: 890844bfe8966023d8b32ba286be159712509005e7c88eb71ba87f9ab6454cc8cbb2e5922e14ba524a147bb2adff2c82563f9c5e7e2331c6dcdef0fbe18e4f97
+  languageName: node
+  linkType: hard
+
 "@jupyterlab/notebook@npm:^4.2.2":
   version: 4.2.2
   resolution: "@jupyterlab/notebook@npm:4.2.2"
@@ -3337,6 +3346,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/settingregistry@npm:^4.2.3":
+  version: 4.2.3
+  resolution: "@jupyterlab/settingregistry@npm:4.2.3"
+  dependencies:
+    "@jupyterlab/nbformat": ^4.2.3
+    "@jupyterlab/statedb": ^4.2.3
+    "@lumino/commands": ^2.3.0
+    "@lumino/coreutils": ^2.1.2
+    "@lumino/disposable": ^2.1.2
+    "@lumino/signaling": ^2.1.2
+    "@rjsf/utils": ^5.13.4
+    ajv: ^8.12.0
+    json5: ^2.2.3
+  peerDependencies:
+    react: ">=16"
+  checksum: 72eff0c5af9b6e9c3be36aea7e6b435f4bc52e770284f1c2d49061577d37bbec697afc7fe7673a22ab15e35ce4e88e3a4da485f432f42b1b4ec35bd8dfba4b3c
+  languageName: node
+  linkType: hard
+
 "@jupyterlab/statedb@npm:^4.2.2":
   version: 4.2.2
   resolution: "@jupyterlab/statedb@npm:4.2.2"
@@ -3347,6 +3375,19 @@ __metadata:
     "@lumino/properties": ^2.0.1
     "@lumino/signaling": ^2.1.2
   checksum: 6fbeed16a659b3f0d9b7a86cca91a0fd082c35b500264d58206f8a79640ea34ac00192c749a96c10f8762c6153ef26d3face6e6ce30b0e84479a0a5896254c38
+  languageName: node
+  linkType: hard
+
+"@jupyterlab/statedb@npm:^4.2.3":
+  version: 4.2.3
+  resolution: "@jupyterlab/statedb@npm:4.2.3"
+  dependencies:
+    "@lumino/commands": ^2.3.0
+    "@lumino/coreutils": ^2.1.2
+    "@lumino/disposable": ^2.1.2
+    "@lumino/properties": ^2.0.1
+    "@lumino/signaling": ^2.1.2
+  checksum: 6969e54fa8370a918a4d78391116b83bd3c5afb25e1f66d7369ac2d24659b89a32bbb23500d81b50744698c504a47bd8bc355b16e4ec6ea877b74ec512aab3f8
   languageName: node
   linkType: hard
 
@@ -8598,6 +8639,7 @@ __metadata:
     "@jupyterlab/application": ^4.0.0
     "@jupyterlab/builder": ^4.0.0
     "@jupyterlab/coreutils": ^6.2.2
+    "@jupyterlab/settingregistry": ^4.2.3
     "@jupyterlab/statedb": ^4.2.2
     "@jupyterlab/testutils": ^4.0.0
     "@lumino/coreutils": 2.1.2


### PR DESCRIPTION
Added a flag in settings which enables or disables the bucket switching UI. The flag can be accessed from the `Settings Editor` menu, in the `Jupydrive-s3 Settings` section.