### PR TITLE
Update `eslintIgnore` and `.prettierignore`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ node_modules
 **/package.json
 !/package.json
 jupydrive_s3
+CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs fixed
 
-- Fix root formatting  [#31](https://github.com/QuantStack/jupydrive-s3/pull/31) ([@DenisaCG](https://github.com/DenisaCG))
+- Fix root formatting [#31](https://github.com/QuantStack/jupydrive-s3/pull/31) ([@DenisaCG](https://github.com/DenisaCG))
 
 ### Contributors to this release
 

--- a/package.json
+++ b/package.json
@@ -116,7 +116,8 @@
         "**/*.d.ts",
         "tests",
         "**/__tests__",
-        "ui-tests"
+        "ui-tests",
+        "CHANGELOG.md"
     ],
     "eslintConfig": {
         "extends": [


### PR DESCRIPTION
Ignore `CHANGELOG.md` when running lint check.