### PR TITLE
Update logic for checking object type

### DIFF
--- a/src/s3.ts
+++ b/src/s3.ts
@@ -402,7 +402,11 @@ export const renameS3Objects = async (
   newLocalPath = PathExt.join(root, newLocalPath);
   oldLocalPath = PathExt.join(root, oldLocalPath);
 
-  const isDir: boolean = PathExt.extname(oldLocalPath) === '';
+  const isDir: boolean = await checkDirectory(
+    s3Client,
+    bucketName,
+    oldLocalPath
+  );
 
   if (isDir) {
     newLocalPath = newLocalPath.substring(0, newLocalPath.length - 1);
@@ -514,7 +518,7 @@ export const copyS3Objects = async (
   registeredFileTypes: IRegisteredFileTypes,
   newBucketName?: string
 ): Promise<Contents.IModel> => {
-  const isDir: boolean = PathExt.extname(path) === '';
+  const isDir: boolean = await checkDirectory(s3Client, bucketName, path);
   let suffix: string = '';
 
   path = PathExt.join(root, path);
@@ -640,6 +644,27 @@ export const countS3ObjectNameAppearances = async (
 
   return counter;
 };
+
+export async function checkDirectory(
+  s3Client: S3Client,
+  bucketName: string,
+  objectPath: string
+): Promise<boolean> {
+  let isDir: boolean = false;
+
+  // listing contents given a path, to check if it is a directory
+  const command = new ListObjectsV2Command({
+    Bucket: bucketName,
+    Prefix: objectPath + '/'
+  });
+
+  const { Contents } = await s3Client.send(command);
+  if (Contents) {
+    isDir = true;
+  }
+
+  return isDir;
+}
 
 namespace Private {
   /**

--- a/src/s3.ts
+++ b/src/s3.ts
@@ -402,7 +402,7 @@ export const renameS3Objects = async (
   newLocalPath = PathExt.join(root, newLocalPath);
   oldLocalPath = PathExt.join(root, oldLocalPath);
 
-  const isDir: boolean = await checkDirectory(
+  const isDir: boolean = await isDirectory(
     s3Client,
     bucketName,
     oldLocalPath
@@ -518,7 +518,7 @@ export const copyS3Objects = async (
   registeredFileTypes: IRegisteredFileTypes,
   newBucketName?: string
 ): Promise<Contents.IModel> => {
-  const isDir: boolean = await checkDirectory(s3Client, bucketName, path);
+  const isDir: boolean = await isDirectory(s3Client, bucketName, path);
   let suffix: string = '';
 
   path = PathExt.join(root, path);
@@ -645,7 +645,10 @@ export const countS3ObjectNameAppearances = async (
   return counter;
 };
 
-export async function checkDirectory(
+/**
+ * This is a helper function that resolves whether a given path
+ * is a directory, because the S3 API does not provide this in listings.
+export async function isDirectory(
   s3Client: S3Client,
   bucketName: string,
   objectPath: string

--- a/src/s3.ts
+++ b/src/s3.ts
@@ -402,11 +402,7 @@ export const renameS3Objects = async (
   newLocalPath = PathExt.join(root, newLocalPath);
   oldLocalPath = PathExt.join(root, oldLocalPath);
 
-  const isDir: boolean = await isDirectory(
-    s3Client,
-    bucketName,
-    oldLocalPath
-  );
+  const isDir: boolean = await isDirectory(s3Client, bucketName, oldLocalPath);
 
   if (isDir) {
     newLocalPath = newLocalPath.substring(0, newLocalPath.length - 1);
@@ -648,6 +644,7 @@ export const countS3ObjectNameAppearances = async (
 /**
  * This is a helper function that resolves whether a given path
  * is a directory, because the S3 API does not provide this in listings.
+ */
 export async function isDirectory(
   s3Client: S3Client,
   bucketName: string,

--- a/src/s3contents.ts
+++ b/src/s3contents.ts
@@ -19,7 +19,8 @@ import {
   renameS3Objects,
   listS3Contents,
   IRegisteredFileTypes,
-  getS3FileContents
+  getS3FileContents,
+  checkDirectory
 } from './s3';
 
 let data: Contents.IModel = {
@@ -483,7 +484,11 @@ export class Drive implements Contents.IDrive {
    * @param root - The root of the bucket, if it exists.
    */
   async incrementName(localPath: string, bucketName: string) {
-    const isDir: boolean = PathExt.extname(localPath) === '';
+    const isDir: boolean = await checkDirectory(
+      this._s3Client,
+      bucketName,
+      localPath
+    );
     let fileExtension: string = '';
     let originalName: string = '';
 
@@ -567,7 +572,11 @@ export class Drive implements Contents.IDrive {
    *  file is copied.
    */
   async incrementCopyName(copiedItemPath: string, bucketName: string) {
-    const isDir: boolean = PathExt.extname(copiedItemPath) === '';
+    const isDir: boolean = await checkDirectory(
+      this._s3Client,
+      bucketName,
+      copiedItemPath
+    );
 
     // extracting original file name
     const originalFileName = PathExt.basename(copiedItemPath);

--- a/src/s3contents.ts
+++ b/src/s3contents.ts
@@ -20,7 +20,7 @@ import {
   listS3Contents,
   IRegisteredFileTypes,
   getS3FileContents,
-  checkDirectory
+  isDirectory
 } from './s3';
 
 let data: Contents.IModel = {
@@ -484,7 +484,7 @@ export class Drive implements Contents.IDrive {
    * @param root - The root of the bucket, if it exists.
    */
   async incrementName(localPath: string, bucketName: string) {
-    const isDir: boolean = await checkDirectory(
+    const isDir: boolean = await isDirectory(
       this._s3Client,
       bucketName,
       localPath
@@ -572,7 +572,7 @@ export class Drive implements Contents.IDrive {
    *  file is copied.
    */
   async incrementCopyName(copiedItemPath: string, bucketName: string) {
-    const isDir: boolean = await checkDirectory(
+    const isDir: boolean = await isDirectory(
       this._s3Client,
       bucketName,
       copiedItemPath


### PR DESCRIPTION
Update the logic of checking the object type (directory or file) by using a helping function which lists the contents given a path. A directory should have some items listed given the path, while a single file would not return anything. This solution would fix the corner cases of having a directory with a name which includes a `.` in it, and hence could have an extension name extracted. 