### PR TITLE
Update `getFileType` function

### DIFF
--- a/src/s3.ts
+++ b/src/s3.ts
@@ -583,26 +583,41 @@ export const copyS3Objects = async (
     registeredFileTypes
   );
 
-  // retrieve information of new file
-  const newFileContents = await s3Client.send(
-    new GetObjectCommand({
-      Bucket: newBucketName ?? bucketName,
-      Key: name + (suffix ? suffix : '')
-    })
-  );
+  try {
+    const newFileContents = await s3Client.send(
+      new GetObjectCommand({
+        Bucket: newBucketName ?? bucketName,
+        Key: name + (suffix ? suffix : '')
+      })
+    );
 
-  data = {
-    name: PathExt.basename(name),
-    path: name,
-    last_modified: newFileContents.LastModified!.toISOString(),
-    created: new Date().toISOString(),
-    content: await newFileContents.Body!.transformToString(),
-    format: fileFormat as Contents.FileFormat,
-    mimetype: fileMimeType,
-    size: newFileContents.ContentLength!,
-    writable: true,
-    type: fileType
-  };
+    data = {
+      name: PathExt.basename(name),
+      path: name,
+      last_modified: newFileContents.LastModified!.toISOString(),
+      created: new Date().toISOString(),
+      content: await newFileContents.Body!.transformToString(),
+      format: fileFormat as Contents.FileFormat,
+      mimetype: fileMimeType,
+      size: newFileContents.ContentLength!,
+      writable: true,
+      type: fileType
+    };
+  } catch {
+    // object directory itself doesn't exist
+    data = {
+      name: PathExt.basename(name),
+      path: name,
+      last_modified: new Date().toISOString(),
+      created: new Date().toISOString(),
+      content: [],
+      format: fileFormat as Contents.FileFormat,
+      mimetype: fileMimeType,
+      size: 0,
+      writable: true,
+      type: fileType
+    };
+  }
 
   return data;
 };

--- a/src/s3.ts
+++ b/src/s3.ts
@@ -404,6 +404,7 @@ export const checkS3Object = async (
  * @param oldLocalPath: The old path of the object.
  * @param newLocalPath: The new path of the object.
  * @param newFileName: The new object name.
+ * @param isDir: Whether the object is a directory or a file.
  * @param registeredFileTypes: The list containing all registered file types.
  *
  * @returns A promise which resolves with the new object contents model.
@@ -415,12 +416,12 @@ export const renameS3Objects = async (
   oldLocalPath: string,
   newLocalPath: string,
   newFileName: string,
+  isDir: boolean,
   registeredFileTypes: IRegisteredFileTypes
 ): Promise<Contents.IModel> => {
   newLocalPath = PathExt.join(root, newLocalPath);
   oldLocalPath = PathExt.join(root, oldLocalPath);
 
-  const isDir: boolean = await isDirectory(s3Client, bucketName, oldLocalPath);
   if (isDir) {
     newLocalPath = newLocalPath.substring(0, newLocalPath.length - 1);
   }

--- a/src/s3.ts
+++ b/src/s3.ts
@@ -83,6 +83,7 @@ export const listS3Contents = async (
   registeredFileTypes: IRegisteredFileTypes,
   path?: string
 ): Promise<Contents.IModel> => {
+  let isFile: boolean = false;
   const fileList: IContentsList = {};
   const prefix = path ? PathExt.join(root, path) : root;
 
@@ -133,25 +134,37 @@ export const listS3Contents = async (
           };
         }
       });
+    } else {
+      isFile = true;
+      data = await getS3FileContents(
+        s3Client,
+        bucketName,
+        root,
+        path!,
+        registeredFileTypes
+      );
     }
+
     if (isTruncated) {
       isTruncated = IsTruncated;
     }
     command.input.ContinuationToken = NextContinuationToken;
   }
 
-  data = {
-    name: path ? PathExt.basename(path) : bucketName,
-    path: path ? path + '/' : bucketName,
-    last_modified: '',
-    created: '',
-    content: Object.values(fileList),
-    format: 'json',
-    mimetype: '',
-    size: undefined,
-    writable: true,
-    type: 'directory'
-  };
+  if (isFile === false) {
+    data = {
+      name: path ? PathExt.basename(path) : bucketName,
+      path: path ? path + '/' : bucketName,
+      last_modified: '',
+      created: '',
+      content: Object.values(fileList),
+      format: 'json',
+      mimetype: '',
+      size: undefined,
+      writable: true,
+      type: 'directory'
+    };
+  }
 
   return data;
 };

--- a/src/s3.ts
+++ b/src/s3.ts
@@ -674,7 +674,8 @@ export async function isDirectory(
   // listing contents given a path, to check if it is a directory
   const command = new ListObjectsV2Command({
     Bucket: bucketName,
-    Prefix: objectPath + '/'
+    Prefix:
+      objectPath[objectPath.length - 1] === '/' ? objectPath : objectPath + '/'
   });
 
   const { Contents } = await s3Client.send(command);

--- a/src/s3contents.ts
+++ b/src/s3contents.ts
@@ -19,7 +19,6 @@ import {
   renameS3Objects,
   listS3Contents,
   IRegisteredFileTypes,
-  getS3FileContents,
   isDirectory
 } from './s3';
 
@@ -287,28 +286,14 @@ export class Drive implements Contents.IDrive {
         this._registeredFileTypes
       );
     } else {
-      const isDir = await isDirectory(this._s3Client, this._name, path);
-
-      // listing contents of a folder
-      if (isDir === true) {
-        data = await listS3Contents(
-          this._s3Client,
-          this._name,
-          this.root,
-          this.registeredFileTypes,
-          path
-        );
-      }
-      // getting the contents of a specific file
-      else {
-        data = await getS3FileContents(
-          this._s3Client,
-          this._name,
-          this._root,
-          path,
-          this.registeredFileTypes
-        );
-      }
+      // listing the contents of a directory or retriving the contents of a file
+      data = await listS3Contents(
+        this._s3Client,
+        this._name,
+        this.root,
+        this.registeredFileTypes,
+        path
+      );
     }
 
     Contents.validateContentsModel(data);

--- a/src/s3contents.ts
+++ b/src/s3contents.ts
@@ -287,10 +287,10 @@ export class Drive implements Contents.IDrive {
         this._registeredFileTypes
       );
     } else {
-      const currentPath = PathExt.basename(path);
+      const isDir = await isDirectory(this._s3Client, this._name, path);
 
       // listing contents of a folder
-      if (PathExt.extname(currentPath) === '') {
+      if (isDir === true) {
         data = await listS3Contents(
           this._s3Client,
           this._name,
@@ -345,7 +345,8 @@ export class Drive implements Contents.IDrive {
         name,
         options.path ? PathExt.join(options.path, name) : name,
         '', // create new file with empty body,
-        this.registeredFileTypes
+        this.registeredFileTypes,
+        options.type === 'directory' ? true : false
       );
     } else {
       console.warn('Type of new element is undefined');
@@ -549,6 +550,7 @@ export class Drive implements Contents.IDrive {
       localPath,
       options.content,
       this._registeredFileTypes,
+      true,
       options
     );
 

--- a/src/s3contents.ts
+++ b/src/s3contents.ts
@@ -277,24 +277,14 @@ export class Drive implements Contents.IDrive {
       this._isRootFormatted = true;
     }
 
-    // getting the list of files from the root
-    if (!path) {
-      data = await listS3Contents(
-        this._s3Client,
-        this._name,
-        this._root,
-        this._registeredFileTypes
-      );
-    } else {
-      // listing the contents of a directory or retriving the contents of a file
-      data = await listS3Contents(
-        this._s3Client,
-        this._name,
-        this.root,
-        this.registeredFileTypes,
-        path
-      );
-    }
+    // listing the contents of a directory or retriving the contents of a file
+    data = await listS3Contents(
+      this._s3Client,
+      this._name,
+      this.root,
+      this.registeredFileTypes,
+      path
+    );
 
     Contents.validateContentsModel(data);
     return data;

--- a/src/s3contents.ts
+++ b/src/s3contents.ts
@@ -442,6 +442,7 @@ export class Drive implements Contents.IDrive {
         oldLocalPath,
         newLocalPath,
         newFileName,
+        isDir,
         this._registeredFileTypes
       );
     }


### PR DESCRIPTION
Update `getFileType` function to consider directories which include `.` in their names (a false extension), when returning the object type, mimetype and format.

This PR builds on #34 and refactors the functionalities to integrate the directory check and remove redundancy. 