### PR TITLE
Add limit to object listings in helping functions

### DIFF
--- a/src/s3.ts
+++ b/src/s3.ts
@@ -376,24 +376,21 @@ export const checkS3Object = async (
   path?: string,
   isDir?: boolean
 ): Promise<void> => {
-  // checking the existance of an S3 object
-  if (path) {
-    await s3Client.send(
-      new HeadObjectCommand({
-        Bucket: bucketName,
-        Key: PathExt.join(root, path) + (isDir === true ? '/' : '')
-      })
-    );
-  }
-  // checking if the root folder exists
-  else {
-    await s3Client.send(
-      new ListObjectsV2Command({
-        Bucket: bucketName,
-        Prefix: root + '/',
-        MaxKeys: 1
-      })
-    );
+  // checking the existance of an S3 object or if root folder exists
+  const prefix: string = path
+    ? PathExt.join(root, path) + (isDir === true ? '/' : '')
+    : root + '/';
+  const { Contents } = await s3Client.send(
+    new ListObjectsV2Command({
+      Bucket: bucketName,
+      Prefix: prefix,
+      MaxKeys: 1
+    })
+  );
+  if (Contents) {
+    Promise.resolve();
+  } else {
+    Promise.reject();
   }
 };
 

--- a/src/s3.ts
+++ b/src/s3.ts
@@ -390,7 +390,8 @@ export const checkS3Object = async (
     await s3Client.send(
       new ListObjectsV2Command({
         Bucket: bucketName,
-        Prefix: root + '/'
+        Prefix: root + '/',
+        MaxKeys: 1
       })
     );
   }
@@ -696,7 +697,8 @@ export async function isDirectory(
   const command = new ListObjectsV2Command({
     Bucket: bucketName,
     Prefix:
-      objectPath[objectPath.length - 1] === '/' ? objectPath : objectPath + '/'
+      objectPath[objectPath.length - 1] === '/' ? objectPath : objectPath + '/',
+    MaxKeys: 1
   });
 
   const { Contents } = await s3Client.send(command);


### PR DESCRIPTION
Add `MaxKeys` parameter to object listings that are used to either check the existence of an object within the bucket or for type of object (directory or file), in order to make sure we don't wait unnecessarily for requests returning a large amounts of objects. 

The `checkS3Object` function is also refactored to take into account directories which don't contain the directory object itself.