### PR TITLE
Disable directory rename

### DIFF
--- a/schema/file-browser-toolbar.json
+++ b/schema/file-browser-toolbar.json
@@ -11,6 +11,12 @@
   "jupyter.lab.menus": {
     "context": [
       {
+        "command": "filebrowser:rename",
+        "selector": ".jp-DirListing-item[data-isdir]",
+        "rank": 5,
+        "disabled": true
+      },
+      {
         "command": "drives:rename",
         "selector": ".jp-DirListing-item[data-isdir]",
         "rank": 5

--- a/schema/file-browser-toolbar.json
+++ b/schema/file-browser-toolbar.json
@@ -8,6 +8,15 @@
       }
     ]
   },
+  "jupyter.lab.menus": {
+    "context": [
+      {
+        "command": "drives:rename",
+        "selector": ".jp-DirListing-item[data-isdir]",
+        "rank": 5
+      }
+    ]
+  },
   "jupyter.lab.setting-icon": "jupydrive-s3:drive",
   "jupyter.lab.setting-icon-label": "Drive Browser",
   "title": "Jupydrive-s3 Settings",

--- a/src/index.ts
+++ b/src/index.ts
@@ -528,6 +528,7 @@ namespace Private {
         !!tracker.currentWidget &&
         Array.from(tracker.currentWidget.selectedItems()).length === 1,
       isEnabled: () =>
+        // Disable directory rename for S3 folders.
         !!tracker.currentWidget &&
         tracker.currentWidget?.selectedItems().next()!.value.type !==
           'directory',

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import {
   Uploader
 } from '@jupyterlab/filebrowser';
 import { IStateDB } from '@jupyterlab/statedb';
+import { editIcon } from '@jupyterlab/ui-components';
 
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { ITranslator } from '@jupyterlab/translation';
@@ -44,6 +45,7 @@ namespace CommandIDs {
   export const copyToAnotherBucket = 'drives:copy-to-another-bucket';
   export const toggleBucketSwitching = 'drives:toggle-bucket-switching-ui';
   export const toggleBrowser = 'filebrowser:toggle-main';
+  export const rename = 'drives:rename';
 }
 
 const FILE_BROWSER_FACTORY = 'DriveBrowser';
@@ -510,6 +512,28 @@ namespace Private {
       selector:
         '.jp-SidePanel .jp-DirListing-content .jp-DirListing-item[data-isDir]',
       rank: 10
+    });
+
+    app.commands.addCommand(CommandIDs.rename, {
+      execute: args => {
+        const widget = tracker.currentWidget;
+
+        if (widget) {
+          return widget.rename();
+        }
+      },
+      isVisible: () =>
+        // So long as this command only handles one file at time, don't show it
+        // if multiple files are selected.
+        !!tracker.currentWidget &&
+        Array.from(tracker.currentWidget.selectedItems()).length === 1,
+      isEnabled: () =>
+        !!tracker.currentWidget &&
+        tracker.currentWidget?.selectedItems().next()!.value.type !==
+          'directory',
+      icon: editIcon.bindprops({ stylesheet: 'menuItem' }),
+      label: 'Rename',
+      mnemonic: 0
     });
   }
 


### PR DESCRIPTION
Disable directory rename as `S3` has rename disabled for folders and no straight-forward functionality to do so transparently.

The rename logic is still present and entails copying each individual object inside the original folder and then deleting it, but it will not be accessed for directory renames. 

![image](https://github.com/user-attachments/assets/f917fce1-a595-4e89-9221-80d881e363e8)
